### PR TITLE
Missing keywords to activate PhaseTransitions

### DIFF
--- a/src/LaMEM_ModelGeneration/Materials.jl
+++ b/src/LaMEM_ModelGeneration/Materials.jl
@@ -562,26 +562,6 @@ function Write_LaMEM_InputFile(io, d::Materials)
         println(io,"")
     end
     
-    # Define PhaseTransitions laws
-    println(io, "   # Define Phase Transition laws (maximum 10)")
-    for PT in d.PhaseTransitions
-      
-        println(io, "   <PhaseTransitionStart>")
-        
-        pt_fields    = fieldnames(typeof(PT))
-        for pt in pt_fields
-            if !isnothing(getfield(PT,pt))
-                name = rpad(String(pt),15)
-                comment = get_doc(PhaseTransition, pt)
-                data = getfield(PT,pt) 
-                println(io,"        $name  = $(write_vec(data))     # $(comment)")
-            end
-        end
-
-        println(io,"   <PhaseTransitionEnd>")
-        println(io,"")
-    end
-    
     # Define Dikes parameters
     if length(d.Dikes)>0
         println(io, "   # Define properties for the dike (additional source term/RHS in the continuity equation):   ")
@@ -626,6 +606,32 @@ function Write_LaMEM_InputFile(io, d::Materials)
         println(io,"")
     end
     println(io,"")
+
+    # Define PhaseTransitions laws
+    println(io, "#===============================================================================")
+    println(io, "# Define phase transitions")
+    println(io, "#===============================================================================")
+    println(io,"")
+
+    println(io, "   # Define Phase Transition laws (maximum 10)")
+    for PT in d.PhaseTransitions
+      
+        println(io, "   <PhaseTransitionStart>")
+        
+        pt_fields    = fieldnames(typeof(PT))
+        for pt in pt_fields
+            if !isnothing(getfield(PT,pt))
+                name = rpad(String(pt),15)
+                comment = get_doc(PhaseTransition, pt)
+                data = getfield(PT,pt) 
+                println(io,"        $name  = $(write_vec(data))     # $(comment)")
+            end
+        end
+
+        println(io,"   <PhaseTransitionEnd>")
+        println(io,"")
+    end
+
 
     return nothing
 end

--- a/src/LaMEM_ModelGeneration/Materials.jl
+++ b/src/LaMEM_ModelGeneration/Materials.jl
@@ -285,13 +285,13 @@ Base.@kwdef mutable struct PhaseTransition
     PTBox_Bounds::Union{Vector{Float64}, Nothing} =   nothing   
     
     "1: only check particles in the vicinity of the box boundaries (2: in all directions)"
-    BoxVicinity::Union{Int64, Nothing} 	        =	1								
+    BoxVicinity::Union{Int64, Nothing} 	        =	nothing								
 
     "[T = Temperature, P = Pressure, Depth = z-coord, X=x-coord, Y=y-coord, APS = accumulated plastic strain, MeltFraction, t = time] parameter that triggers the phase transition"
-    Parameter_transition::String                =   "T"     
+    Parameter_transition::Union{String, Nothing}   =   nothing   
 
     "Value of the parameter [unit of T,P,z, APS] "        
-    ConstantValue::Union{Float64, Nothing}      =   1200          
+    ConstantValue::Union{Float64, Nothing}      =   nothing          
 
     "The number of involved phases [default=1]"
     number_phases::Union{Int64, Nothing}        =   1              
@@ -309,13 +309,13 @@ Base.@kwdef mutable struct PhaseTransition
     PhaseOutside::Union{Vector{Int64}, Nothing} =   nothing       
 
     "[BothWays=default; BelowToAbove; AboveToBelow] Direction in which transition works"
-    PhaseDirection::String                      =   "BothWays"      
+    PhaseDirection::Union{String, Nothing}      =   nothing 
 
     "[APS] Parameter to reset on particles below PT or within box"
-    ResetParam::String                          =   "APS"        
+    ResetParam::Union{String, Nothing}          =  nothing  
     
     "# Temperature condition witin the box [none, constant, linear, halfspace]"
-    PTBox_TempType::String                      =   "linear"          
+    PTBox_TempType::Union{String, Nothing}      =   nothing         
     
     "Temp @ top of box [for linear & halfspace] "               
     PTBox_topTemp::Union{Float64, Nothing}      =   nothing                        

--- a/src/LaMEM_ModelGeneration/Materials.jl
+++ b/src/LaMEM_ModelGeneration/Materials.jl
@@ -279,7 +279,7 @@ Base.@kwdef mutable struct PhaseTransition
     Type::String                    =   "Constant"      
     
     "Type of predefined Clapeyron slope, such as Mantle_Transition_660km"
-    Name_Clapeyron::Union{Int64, Nothing}          =  nothing
+    Name_Clapeyron::Union{String, Nothing}          =  nothing
 
     "box bound coordinates: [left, right, front, back, bottom, top]"
     PTBox_Bounds::Union{Vector{Float64}, Nothing} =   nothing   
@@ -336,7 +336,17 @@ Base.@kwdef mutable struct PhaseTransition
     t0_box::Union{Float64, Nothing}   =   nothing                    
 
     "[optional] end time of movement in Myr"
-    t1_box::Union{Float64, Nothing}   =   nothing                         
+    t1_box::Union{Float64, Nothing}   =   nothing   
+    
+    "[optional] clapeyron slope of phase transition [in K/MPa]; P=(T-T0_clapeyron)*clapeyron_slope + P0_clapeyron "
+    clapeyron_slope::Union{Float64, Nothing}   =   nothing   
+    
+    "[optional] P0_clapeyron [Pa]"
+    P0_clapeyron::Union{Float64, Nothing}   =   nothing   
+    
+    "[optional] T0_clapeyron [C]"
+    T0_clapeyron::Union{Float64, Nothing}   =   nothing   
+    
 end
 
 function show(io::IO, d::PhaseTransition)

--- a/src/LaMEM_ModelGeneration/Model.jl
+++ b/src/LaMEM_ModelGeneration/Model.jl
@@ -148,7 +148,10 @@ function Write_LaMEM_InputFile(d::Model, fname::String="input.dat"; dir=pwd())
         # If we want to write an input file 
         Write_Paraview(CartData(d.Grid.Grid, (Phases=d.Grid.Phases,Temp=d.Grid.Temp)),"Model3D")
     end
-
+    if !isempty(d.Materials.PhaseTransitions)
+        # If PhaseTransitions are defined, we generally want this to be activated in computations
+        d.SolutionParams.Phasetrans = 1
+    end
         
     io = open(fname,"w")
 

--- a/src/LaMEM_ModelGeneration/ModelSetup.jl
+++ b/src/LaMEM_ModelGeneration/ModelSetup.jl
@@ -36,7 +36,7 @@ Base.@kwdef mutable struct ModelSetup
     temp_file::String   = "./input/temp.dat"  
 
     "advection scheme; options=`none` (no advection); `basic` (Euler classical implementation [default]); `Euler` (Euler explicit in time); `rk2` (Runge-Kutta 2nd order in space)"
-    advect::String      = "basic"             
+    advect::String      = "rk2"             
 
     "velocity interpolation scheme; options = `stag` (trilinear interpolation from FDSTAG points), `minmod` ( MINMOD interpolation to nodes, trilinear interpolation to markers + correction), `stagp` ( STAG_P empirical approach by T. Gerya) "
     interp::String      = "stag"              
@@ -162,11 +162,15 @@ function Write_LaMEM_InputFile(io, d::ModelSetup)
     println(io,"")
 
     for f in fields
+
+    
         if getfield(d,f) != getfield(Reference,f)  ||
-            (f == :bg_phase) ||
-            (f == :msetup) ||
-            (f == :rand_noise) ||
-            (f == :nmark_lim) ||
+            (f == :bg_phase)    ||
+            (f == :msetup)      ||
+            (f == :rand_noise)  ||
+            (f == :nmark_lim)   ||
+            (f == :advect)      ||
+            (f == :interp)      ||
             (f == :mark_ctrl)
             
             

--- a/src/LaMEM_ModelGeneration/Scaling.jl
+++ b/src/LaMEM_ModelGeneration/Scaling.jl
@@ -44,10 +44,10 @@ function Write_LaMEM_InputFile(io, d::Scaling)
         char_L = uconvert(u"m",d.Scaling.length);
         char_η = uconvert(u"Pa*s",d.Scaling.viscosity);
         char_τ = uconvert(u"Pa",d.Scaling.stress);
-        println(io,"    unit_temperature = $char_T")
-        println(io,"    unit_length      = $char_L")
-        println(io,"    unit_viscosity   = $char_η")
-        println(io,"    unit_stress      = $char_τ")
+        println(io,"    unit_temperature = $(ustrip.(char_T))")
+        println(io,"    unit_length      = $(ustrip(char_L))")
+        println(io,"    unit_viscosity   = $(ustrip(char_η))")
+        println(io,"    unit_stress      = $(ustrip(char_τ))")
 
     elseif isa(d,Scaling{GeoUnits{NONE}}) 
         println(io,"    units = none")

--- a/src/LaMEM_ModelGeneration/SolutionParams.jl
+++ b/src/LaMEM_ModelGeneration/SolutionParams.jl
@@ -50,7 +50,7 @@ Base.@kwdef mutable struct SolutionParams
     act_heat_rech::Int64   = 1               
 
     "sets initial pressure to be the lithostatic pressure (stabilizes compressible setups in the first steps)"
-    init_lith_pres::Int64  = 1       
+    init_lith_pres::Int64  = 0       
     
     "create an initial guess step (using constant viscosity `eta_ref` before starting the simulation"
     init_guess::Int64      = 1              

--- a/src/LaMEM_ModelGeneration/SolutionParams.jl
+++ b/src/LaMEM_ModelGeneration/SolutionParams.jl
@@ -128,6 +128,9 @@ Base.@kwdef mutable struct SolutionParams
     "compute the velocity gradient tensor 1: active, 0: not active. If active, it automatically activates the output in the .pvd file"
     Compute_velocity_gradient::Int64 = 1     
     
+    "Activate Phase Transitions on Particles or not, 0: not. "
+    Phasetrans::Int64 = 0     
+    
 end
 
 # Print info about the structure

--- a/src/LaMEM_ModelGeneration/SolutionParams.jl
+++ b/src/LaMEM_ModelGeneration/SolutionParams.jl
@@ -20,6 +20,11 @@ Base.@kwdef mutable struct SolutionParams
     """
     FSSA::Float64            = 1.0         
 
+    """
+    free surface stabilization parameter applied to all velocity components?  Default is yes; if not it is only applied to the z-component
+    """
+    FSSA_allVel::Int64       = 1 
+
     "shear heating efficiency parameter   [0 - 1]"   
     shear_heat_eff::Float64  = 1.0             
     
@@ -123,13 +128,19 @@ Base.@kwdef mutable struct SolutionParams
     useTk::Int64            = 1              
     
     "switch to use Behn & Ito heat source in the dike "
-    dikeHeat::Int64         = 1		        
+    dikeHeat::Int64         = 1		  
+    
+    "Adiabatic gradient in combination with Behn & Ito dike "
+    adiabatic_gradient::Float64 = 1.0
 
     "compute the velocity gradient tensor 1: active, 0: not active. If active, it automatically activates the output in the .pvd file"
     Compute_velocity_gradient::Int64 = 1     
     
     "Activate Phase Transitions on Particles or not, 0: not. "
     Phasetrans::Int64 = 0     
+
+    "Activate Passive Tracers or not?"
+    Passive_Tracer::Int64 = 0 
     
 end
 

--- a/test/test_julia_setups.jl
+++ b/test/test_julia_setups.jl
@@ -96,8 +96,10 @@ using GeophysicalModelGenerator
     # Main model setup
     model  = Model(Grid(nel=(64,1,64), x=[-500,500], coord_y=[-10,10], coord_z=[-1000,50]),
                     Time(nstep_max=30, nstep_out=5, dt=0.01, dt_max=1, dt_min=1e-5), 
+                    Scaling(GEO_units(length = 100km) ),
                     BoundaryConditions(temp_bot=1300, noslip=[0,0,0,0,1,0], open_top_bound=1),
-                    Output(out_velocity=1, out_dir="example_2", out_file_name="Plume_PhaseTransitions", out_temperature=1))
+                    SolutionParams(init_lith_pres=1),
+                    Output(out_velocity=1, out_file_name="Plume_PhaseTransitions_new", out_temperature=1))
 
     # Specify material properties
     air     = Phase(ID=0,Name="Air",     eta=1e22, rho=3300, alpha=3e-5,  k=100, Cp=1e6)
@@ -142,12 +144,10 @@ using GeophysicalModelGenerator
     # run the simulation on 1 core
     run_lamem(model, 1);
 
-
-    # # read last timestep
     # read last timestep
     data,time = Read_LaMEM_timestep(model,last=true);
 
-    @test  sum(data.fields.phase) ≈ 29495.215f0
+    @test  sum(data.fields.phase) ≈ 29160.412f0
     
     # cleanup the directory
     rm(model.Output.out_dir, force=true, recursive=true)


### PR DESCRIPTION
PhaseTransitions were inactive because a keyword was not set. 
On the occasion, a few additional missing keywords were added & I made "rk2" the default advection scheme (which was reported to work better by @NicolasRiel).

Fixes issue #26 

NOTE: there was also an issue in LaMEM which made phase transitions to be inactive when `Phase==0` was selected. See [here](https://github.com/UniMainzGeo/LaMEM/issues/14). This [PR](https://github.com/UniMainzGeo/LaMEM/issues/14) fixes that, which should be integrated in version 2.1.4. As a workaround, avoid using `phase=0` for the mantle etc. 