### PR TITLE
add output path in test_erosion.jl

### DIFF
--- a/test/test_erosion.jl
+++ b/test/test_erosion.jl
@@ -9,7 +9,8 @@ using GeophysicalModelGenerator
         # Main model setup
         model = Model(Grid(nel=(32,1,32), x=[-50,50], z=[-50,20], y=[-1,1] ), 
                 Scaling(GEO_units(stress=1000MPa, viscosity=1e20Pa*s)),
-                Time(dt=1e-2, dt_min=1e-5, dt_max=1e-1, nstep_out=5, nstep_max=200, time_end=5))
+                Time(dt=1e-2, dt_min=1e-5, dt_max=1e-1, nstep_out=5, nstep_max=200, time_end=5),
+                Output(out_dir="erosion_test_folder"))
 
         # add an air phase, phase =0 
         add_box!(model;  xlim    = (-50, 50), 


### PR DESCRIPTION
add an output path (out_dir="test_erosion_folder") in test_erosion.jl to address the following error during testing LaMEM (#66 ):
```
Writing LaMEM marker file -> ./markers/mdb.00000000.dat
surface erosion: Error During Test at /Users/wenrongcao/.julia/packages/LaMEM/xQgat/test/test_erosion.jl:7
  Got exception outside of a @test
  SystemError: opening file "./markers/mdb.00000000.dat": Permission denied
```
