### PR TITLE
Plot cross-section through a CartData structure

### DIFF
--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -10,29 +10,55 @@ export plot_topo, plot_cross_section, plot_phasediagram, plot_cross_section_simu
 println("Adding Plots.jl plotting extensions for LaMEM")
 
 """
-    plot_cross_section(model::Union{Model,CartData}, args...; field::Symbol=:phase,  
+    plot_cross_section(model::Model, args...; field::Symbol=:phase,  
                         timestep::Union{Nothing, Int64}=nothing,
                         dim=1, x=nothing, y=nothing, z=nothing, aspect_ratio::Union{Real, Symbol}=:equal)
    
 This plots a cross-section through the LaMEM `model`, of the field  `field`. If that is a vector or tensor field, specify `dim` to indicate which of the fields you want to see.
 If the keyword `timestep` is specified, it will load a timestep 
 """
-function plot_cross_section(model::Union{Model,CartData}, args...; field::Symbol=:phase, 
-        timestep::Union{Nothing, Int64}=nothing, dim=1, 
+function plot_cross_section(model::Model, args...; field::Symbol=:phase, 
+        timestep::Union{Nothing, Int64}=0, dim=1, 
         x=nothing, y=nothing, z=nothing, 
         aspect_ratio::Union{Real, Symbol}=:equal)
 
-    if !isnothing(timestep)
-        # load a particular timestep
-        data_cart, time = read_LaMEM_timestep(model,timestep)
-        model = data_cart
-    end
+    # load a particular timestep
+    data_cart, time_val = read_LaMEM_timestep(model,timestep)
 
     if isnothing(x) && isnothing(y) && isnothing(z)
         x = mean(extrema(model.Grid.Grid.X))
     end
+
+    title_str = ""
+    if !isnothing(timestep)
+        title_str=title_str*" time=$(time_val[1])"
+    end
+
+    hm = plot_cross_section(data_cart, args...; field=field, dim=dim,x=x, y=y, z=z, title_str=title_str, aspect_ratio=aspect_ratio)
+
+    return hm
+end
+
+"""
+    plot_cross_section(data::CartData, args...; field::Symbol=:phase,  
+                        title_str="",
+                        dim=1, x=nothing, y=nothing, z=nothing, aspect_ratio::Union{Real, Symbol}=:equal)
+   
+This plots a cross-section through a `CartData` dataset `data` of the field  `field`, typically read in from a LaMEM simulation.
+If that is a vector or tensor field, specify `dim` to indicate which of the fields you want to see.
+"""
+function plot_cross_section(data::CartData, args...; field::Symbol=:phase, 
+        dim=1, 
+        x=nothing, y=nothing, z=nothing, 
+        title_str="",
+        aspect_ratio::Union{Real, Symbol}=:equal)
+
+   
+    if isnothing(x) && isnothing(y) && isnothing(z)
+        x = mean(extrema(data.x.val))
+    end
     
-    data_tuple, axes_str = cross_section(model, field; x=x, y=y, z=z)
+    data_tuple, axes_str = cross_section(data, field; x=x, y=y, z=z)
     
     if isa(data_tuple.data, Array)
         data_field = data_tuple.data
@@ -41,12 +67,8 @@ function plot_cross_section(model::Union{Model,CartData}, args...; field::Symbol
         data_field = data_tuple.data[dim]
         cb_str = String(field)*"[$dim]"
     end
-
-    title_str = axes_str.title_str
-    if !isnothing(timestep)
-        title_str=title_str*"; time=$(time[1])"
-    end
-
+    title_str *= " "*axes_str.title_str
+ 
     hm = Plots.heatmap(data_tuple.x, data_tuple.z, data_field', 
                 aspect_ratio=aspect_ratio, 
                 xlabel=axes_str.x_str,
@@ -58,14 +80,13 @@ function plot_cross_section(model::Union{Model,CartData}, args...; field::Symbol
     return hm
 end
 
-
 """
-    plot_cross_section_simulation(model::Union{Model,CartData}, args...; field::Symbol=:phase,  
+    plot_cross_section_simulation(model::Model, args...; field::Symbol=:phase,  
                         dim=1, x=nothing, y=nothing, z=nothing, aspect_ratio::Union{Real, Symbol}=:equal)
    
 As `plot_cross_section`, but for the entire simulation instead of a single timestep.
 """
-function plot_cross_section_simulation(model::Union{Model,CartData}, args...; field::Symbol=:phase, 
+function plot_cross_section_simulation(model::Model, args...; field::Symbol=:phase, 
         dim=1, x=nothing, y=nothing, z=nothing, aspect_ratio::Union{Real, Symbol}=:equal)
 
     Timesteps,_,_ = read_LaMEM_simulation(model);


### PR DESCRIPTION
prompted by issue #68, this adds support to plot a cross-section through a LaMEM-created `CartData` structure

MWE
```Julia
julia> using LaMEM, GeophysicalModelGenerator, Plots
julia> model  = Model(Grid(nel=(16,16,16), x=[-1,1], y=[-1,1], z=[-1,1]));
julia> matrix = Phase(ID=0,Name="matrix",eta=1e20,rho=3000);
julia> sphere = Phase(ID=1,Name="sphere",eta=1e23,rho=3200);
julia> add_phase!(model, sphere, matrix)
julia> add_sphere!(model,cen=(0.0,0.0,0.0), radius=0.5);
julia> run_lamem(model,1);
julia> data_cart, time = read_LaMEM_timestep(model,2)
(CartData 
    size    : (17, 17, 17)
    x       ϵ [ -1.0 : 1.0]
    y       ϵ [ -1.0 : 1.0]
    z       ϵ [ -1.0 : 1.0]
    fields  : (:phase, :density, :visc_total, :visc_creep, :velocity, :pressure, :temperature, :j2_dev_stress, :j2_strain_rate)
, [0.0924])
``` 
Next, plot this with:

```Julia
julia> plot_cross_section(data_cart, y=0, field=:phase)
```
<img width="715" alt="Screenshot 2025-01-06 at 15 01 45" src="https://github.com/user-attachments/assets/cf2d410c-9b91-4b63-899b-2aadd339011b" />

