### PR TITLE
Update run_lamem_save_grid.jl

### DIFF
--- a/src/run_lamem_save_grid.jl
+++ b/src/run_lamem_save_grid.jl
@@ -27,7 +27,7 @@ function run_lamem_with_log(ParamFile::String, cores::Int64=1, args::String=""; 
         mpirun = setenv(mpiexec, LaMEM_jll.JLLWrappers.JLLWrappers.LIBPATH_env=>LaMEM_jll.LIBPATH[]);
 
         # create command-line object
-        cmd = `$(mpirun) -n $cores $(LaMEM_jll.LaMEM_path) -ParamFile $(ParamFile) $args`
+        cmd = `$(mpirun) -n $cores $(LaMEM_jll.LaMEM_path) -ParamFile $(ParamFile) $args --map-by :OVERSUBSCRIBE `
         if deactivate_multithreads
             cmd = deactivate_multithreading(cmd)
         end


### PR DESCRIPTION
added oversubscribe option to start app with mpiexec to save markers for higher amount of cores than in the current system