### PR TITLE
Bugfix in plotting cross-section through initial model setup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LaMEM"
 uuid = "2e889f3d-35ce-4a77-8ea2-858aecb630f7"
 authors = ["Boris Kaus <kaus@uni-mainz.de>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -18,13 +18,19 @@ This plots a cross-section through the LaMEM `model`, of the field  `field`. If 
 If the keyword `timestep` is specified, it will load a timestep 
 """
 function plot_cross_section(model::Model, args...; field::Symbol=:phase, 
-        timestep::Union{Nothing, Int64}=0, dim=1, 
+        timestep::Union{Nothing, Int64}=nothing, dim=1, 
         x=nothing, y=nothing, z=nothing, 
         aspect_ratio::Union{Real, Symbol}=:equal)
 
-    # load a particular timestep
-    data_cart, time_val = read_LaMEM_timestep(model,timestep)
-
+    if !isnothing(timestep)
+        # load a particular timestep
+        data_cart, time_val = read_LaMEM_timestep(model,timestep)
+    else
+        # Create a CartData set from initial model setup
+        data_cart = CartData(model.Grid.Grid.X, model.Grid.Grid.Y, model.Grid.Grid.Z, 
+                                (phase=model.Grid.Phases,temperature=model.Grid.Temp))
+    end
+    
     if isnothing(x) && isnothing(y) && isnothing(z)
         x = mean(extrema(model.Grid.Grid.X))
     end
@@ -47,7 +53,7 @@ end
 This plots a cross-section through a `CartData` dataset `data` of the field  `field`, typically read in from a LaMEM simulation.
 If that is a vector or tensor field, specify `dim` to indicate which of the fields you want to see.
 """
-function plot_cross_section(data::CartData, args...; field::Symbol=:phase, 
+function plot_cross_section(data::CartData , args...; field::Symbol=:phase, 
         dim=1, 
         x=nothing, y=nothing, z=nothing, 
         title_str="",

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -76,7 +76,7 @@ function plot_cross_section(data::CartData , args...; field::Symbol=:phase,
         x = mean(extrema(data.x.val))
     end
     
-    data_tuple, axes_str = cross_section(data, field; x=x, y=y, z=z, surf=surf)
+    data_tuple, axes_str = cross_section(data, field; x=x, y=y, z=z)
     
     if isa(data_tuple.data, Array)
         data_field = data_tuple.data


### PR DESCRIPTION
PR #69 introduced bug which no longer allowed plotting cross-sections through the initial model setup (before running LaMEM) as noted in issue #68 

This fixes that.

```julia
julia> using LaMEM, GeophysicalModelGenerator, Plots
julia> model  = Model(Grid(nel=(16,16,16), x=[-1,1], y=[-1,1], z=[-1,1]));
julia> matrix = Phase(ID=0,Name="matrix",eta=1e20,rho=3000);
julia> sphere = Phase(ID=1,Name="sphere",eta=1e23,rho=3200);
julia> add_phase!(model, sphere, matrix)
julia> add_sphere!(model,cen=(0.0,0.0,0.0), radius=0.5);
julia> plot_cross_section(model, y=0, field=:phase)
```
<img width="714" alt="Screenshot 2025-02-16 at 10 34 50" src="https://github.com/user-attachments/assets/13d60d26-83f6-4dae-a538-761991b0b363" />


cc @NicolasRiel, @wenrongcao  