### PR TITLE
fix sedimentation and add a test

### DIFF
--- a/src/LaMEM_ModelGeneration/FreeSurface.jl
+++ b/src/LaMEM_ModelGeneration/FreeSurface.jl
@@ -44,7 +44,7 @@ Base.@kwdef mutable struct FreeSurface
     er_levels::Vector{Int64}    = [1,   2,   1]     
 
     "sedimentation model [0-none (dafault), 1-prescribed rate with given level, 2-cont. margin]"
-    sediment_model::Int64       = 1                 
+    sediment_model::Int64       = 0                 
 
     "number of sediment layers"
     sed_num_layers::Int64       = 3                 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using LaMEM
     include("test_GeoParams_integration.jl")
     include("test_examples.jl")
     include("test_erosion.jl")
-
+    include("test_sedimentation.jl")
 end
 
 if !Sys.iswindows()

--- a/test/test_sedimentation.jl
+++ b/test/test_sedimentation.jl
@@ -1,0 +1,55 @@
+# This tests erosion of the files
+
+using Test
+using LaMEM
+using GeophysicalModelGenerator
+
+@testset "sedimentation erosion" begin
+    if !Sys.iswindows()
+        # Main model setup
+        model = Model(Grid(nel=(50,1,50), x=[-50,50], z=[-50,50], y=[-1,1] ), 
+        Scaling(GEO_units(stress=1000MPa, viscosity=1e20Pa*s)),
+        Time(dt=1e-2, dt_min=1e-5, dt_max=1e-1, nstep_out=5, nstep_max=200, time_end=5),
+        Output(out_dir="sedimentation_test_folder"))
+
+        # add an air phase, phase =0 
+        add_box!(model;  xlim = (-50, 50), ylim = (model.Grid.coord_y...,), zlim = (50, -25),
+                phase   = ConstantPhase(0), T = nothing )    
+
+        # add a crust phase, phase =1
+        add_box!(model;  xlim = (-50, 50), ylim = (model.Grid.coord_y...,), zlim    = (-50.0, -25.0),
+                phase   = ConstantPhase(1), T = nothing )   
+
+        model.FreeSurface = FreeSurface(    surf_use        = 1,                # free surface activation flag
+                                            surf_corr_phase = 1,                # air phase ratio correction flag (due to surface position)
+                                            surf_level      = -25.0,            # initial level
+                                            surf_air_phase  = 0,                # phase ID of sticky air layer
+                                            surf_max_angle  = 40.0,             # maximum angle with horizon (smoothed if larger))
+
+                                            sediment_model  = 1,                # 1-prescribed rate with given level
+                                            sed_num_layers  = 1,                # number of sediment layers
+                                            sed_time_delims = [1],              # sediment layers time delimiters (one less than number)
+                                            sed_rates       = [0.5,0.5],        # sediment rates in different time periods (0.5cm/yr = 5 km/Myr)
+                                            sed_levels      = [0,0],            # levels below which we apply constant sediment rates in different time periods                               
+                                            sed_phases      = [1]               # sediment layers phase numbers in different time periods
+                                            )        
+        #plot_cross_section(model, y=0, field=:phase)
+
+        air    = Phase(ID=0, Name="Air",    eta=1e19, rho=50, ch=10e6, fr=0);
+        crust  =  Phase(ID=1, Name="crust",  eta=1e21, rho=2700, ch=30e6, fr=20);
+        rm_phase!(model)
+        add_phase!(model, air, crust)
+
+        run_lamem(model,1);
+
+        # read last timestep
+        data,time = read_LaMEM_timestep(model,last=true);
+
+        @test  sum(data.fields.phase[32,1,:]) ≈ 25.683678f0 # check sum of phase along a vertical profile
+        
+        # cleanup the directory
+        rm(model.Output.out_dir, force=true, recursive=true)
+
+    end
+
+end

--- a/test/test_sedimentation.jl
+++ b/test/test_sedimentation.jl
@@ -45,7 +45,7 @@ using GeophysicalModelGenerator
         # read last timestep
         data,time = read_LaMEM_timestep(model,last=true);
 
-        @test  sum(data.fields.phase[32,1,:]) ≈ 25.683678f0 # check sum of phase along a vertical profile
+        @test  sum(data.fields.phase[50,1,:]) ≈ 25.683678f0 # check sum of phase along a vertical profile
         
         # cleanup the directory
         rm(model.Output.out_dir, force=true, recursive=true)

--- a/test/test_sedimentation.jl
+++ b/test/test_sedimentation.jl
@@ -4,7 +4,7 @@ using Test
 using LaMEM
 using GeophysicalModelGenerator
 
-@testset "sedimentation erosion" begin
+@testset "sedimentation test" begin
     if !Sys.iswindows()
         # Main model setup
         model = Model(Grid(nel=(50,1,50), x=[-50,50], z=[-50,50], y=[-1,1] ), 


### PR DESCRIPTION
This PR is to fix issues #77 and #62 by changing the default value of sediment_model from 1 to 0 in [src/LaMEM_ModelGeneration/FreeSurface.jl](url). 

By doing so, if a user sets ```sediment_model=1```, such a line will be translated into the output.dat, and sedimentation rate(s) will be activated. 

If the user does not set any sedimentation model, the default value ```sediment_model=0``` (no sedimentation) will be applied. A test code is also added. 

```julia
using LaMEM, GeophysicalModelGenerator,  Plots

# Main model setup
model = Model(Grid(nel=(50,1,50), x=[-50,50], z=[-50,50], y=[-1,1] ), 
        Scaling(GEO_units(stress=1000MPa, viscosity=1e20Pa*s)),
        Time(dt=1e-2, dt_min=1e-5, dt_max=1e-1, nstep_out=5, nstep_max=200, time_end=5))

# add an air phase, phase =0 
add_box!(model;  xlim = (-50, 50), ylim = (model.Grid.coord_y...,), zlim = (50, -25),
        phase   = ConstantPhase(0), T = nothing )    

# add a crust phase, phase =1
add_box!(model;  xlim = (-50, 50), ylim = (model.Grid.coord_y...,), zlim    = (-50.0, -25.0),
        phase   = ConstantPhase(1), T = nothing )   

model.FreeSurface = FreeSurface(    surf_use        = 1,                # free surface activation flag
                                    surf_corr_phase = 1,                # air phase ratio correction flag (due to surface position)
                                    surf_level      = -25.0,            # initial level
                                    surf_air_phase  = 0,                # phase ID of sticky air layer
                                    surf_max_angle  = 40.0,             # maximum angle with horizon (smoothed if larger))

                                    sediment_model  = 1,                # 1-prescribed rate with given level
                                    sed_num_layers  = 1,                # number of sediment layers
                                    sed_time_delims = [1],              # sediment layers time delimiters (one less than number)
                                    sed_rates       = [0.5,0.5],        # sediment rates in different time periods (0.5cm/yr = 5 km/Myr)
                                    sed_levels      = [0,0],            # levels below which we apply constant sediment rates in different time periods                               
                                    sed_phases      = [1]               # sediment layers phase numbers in different time periods
                                    )        
#plot_cross_section(model, y=0, field=:phase)

air    = Phase(ID=0, Name="Air",    eta=1e19, rho=50, ch=10e6, fr=0);
crust  =  Phase(ID=1, Name="crust",  eta=1e21, rho=2700, ch=30e6, fr=20);
rm_phase!(model)
add_phase!(model, air, crust)

run_lamem(model,1)
``` 
Here are the results:
![截屏2025-02-28 下午4 43 31](https://github.com/user-attachments/assets/c9b9632d-dbef-48fb-a709-5bec0d8cb94f)
![截屏2025-02-28 下午4 43 45](https://github.com/user-attachments/assets/e541fc74-3311-4dac-a62a-4fa11d129e2b)

