### PR TITLE
Add "numberofequation" property to PhaseTransition struct

### DIFF
--- a/src/LaMEM_ModelGeneration/Materials.jl
+++ b/src/LaMEM_ModelGeneration/Materials.jl
@@ -568,8 +568,8 @@ Base.@kwdef mutable struct PhaseTransition
     "[optional] T0_clapeyron [C]"
     T0_clapeyron::Union{Float64, Nothing}   =   nothing
     
-    "Number of phase transition equations. Must be 1 or 2 for Clapeyron phase transitions [default=0]"
-    numberofequation::Int64   =   0
+    "Number of phase transition equations. Must be 1 or 2 for Clapeyron phase transitions"
+    numberofequation::Union{Int64, Nothing}   =   nothing
     
 end
 

--- a/src/LaMEM_ModelGeneration/Materials.jl
+++ b/src/LaMEM_ModelGeneration/Materials.jl
@@ -566,7 +566,10 @@ Base.@kwdef mutable struct PhaseTransition
     P0_clapeyron::Union{Float64, Nothing}   =   nothing   
     
     "[optional] T0_clapeyron [C]"
-    T0_clapeyron::Union{Float64, Nothing}   =   nothing   
+    T0_clapeyron::Union{Float64, Nothing}   =   nothing
+    
+    "Number of phase transition equations. Must be 1 or 2 for Clapeyron phase transitions [default=0]"
+    numberofequation::Int64   =   0
     
 end
 


### PR DESCRIPTION
LaMEM throws if the `numberofequation` property for Clapeyron phase transitions is not >0 and <=2 (https://github.com/UniMainzGeo/LaMEM/blob/9e33e7af984f29b586e20d64c1b52f63d0b7221e/src/phase_transition.cpp#L567)

However, the field is missing from the PhaseTransition struct. When setting a custom Clapeyron transition, its value is undefined, leading to the linked error being thrown. Trying to set the property in a PhaseTransition object results in a Julia type error.

This PR adds `numberofequation` as an optional property which defaults to `nothing` so as not to change the behavior of existing codes.

Note: this problem only affects custom Clapeyron transitions, because the Name_Clapeyron transitions override `neq` on the cpp side (e.g. 	https://github.com/UniMainzGeo/LaMEM/blob/9e33e7af984f29b586e20d64c1b52f63d0b7221e/src/phase_transition.cpp#L665)

