### PR TITLE
[Feature] Ability to set initial accumulated plastic strain

### DIFF
--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -34,7 +34,7 @@ function plot_cross_section(model::Model, args...; field::Symbol=:phase,
     else
         # Create a CartData set from initial model setup
         data_cart = CartData(model.Grid.Grid.X, model.Grid.Grid.Y, model.Grid.Grid.Z, 
-                                (phase=model.Grid.Phases,temperature=model.Grid.Temp))
+                                (phase=model.Grid.Phases,temperature=model.Grid.Temp,plast_strain=model.Grid.APS))
     end
     
     if isnothing(x) && isnothing(y) && isnothing(z)

--- a/src/LaMEM_ModelGeneration/DefaultParams.jl
+++ b/src/LaMEM_ModelGeneration/DefaultParams.jl
@@ -27,6 +27,7 @@ function UpdateDefaultParameters(model::Model)
         model.Output.out_ptr_phase=1
         model.Output.out_ptr_Pressure=1
         model.Output.out_ptr_Temperature=1
+        model.Output.out_ptr_APS=0
     end
 
     if  model.BoundaryConditions.open_top_bound==0

--- a/src/LaMEM_ModelGeneration/Grid.jl
+++ b/src/LaMEM_ModelGeneration/Grid.jl
@@ -83,7 +83,10 @@ mutable struct Grid
     Phases  ::  Array{Int32} 
 
     "Temp; 3D phase information"
-    Temp    ::  Array{Float64} 
+    Temp    ::  Array{Float64}
+
+    "APS; accumulated plastic strain"
+    APS     ::  Array{Float64}
 
     # set default parameters
     function Grid(;
@@ -135,10 +138,11 @@ mutable struct Grid
         # Define Phase and Temp structs                                 
         Phases  = zeros(Int32,size(Grid_LaMEM.X));
         Temp    = zeros(Float64,size(Grid_LaMEM.X));
+        APS     = zeros(Float64,size(Grid_LaMEM.X));
 
         # Create struct
         return new(nmark_x, nmark_y, nmark_z, [nel_x...], [nel_y...], [nel_z...], [coord_x...], [coord_y...], [coord_z...], 
-            nseg_x, nseg_y, nseg_z, [bias_x...], [bias_y...], [bias_z...], Grid_LaMEM, Phases, Temp)
+            nseg_x, nseg_y, nseg_z, [bias_x...], [bias_y...], [bias_z...], Grid_LaMEM, Phases, Temp, APS)
     end
 
 end
@@ -189,7 +193,7 @@ function  Create_Grid(nmark_x, nmark_y, nmark_z, nel_x, nel_y, nel_z, coord_x, c
         X,          Y,          Z,
         xn,         yn,         zn,
         Xn,         Yn,         Zn);
-        
+
     return Grid_LaMEM
 end
 
@@ -206,7 +210,7 @@ function show(io::IO, d::Grid)
     print_coord(io, "z", d.coord_z, d.bias_z, d.nseg_z, d.Grid.zn_vec)
     println(io,"  Phases      : range ϵ [$(minimum(d.Phases)) - $(maximum(d.Phases))]")
     println(io,"  Temp        : range ϵ [$(minimum(d.Temp)) - $(maximum(d.Temp))]")
-
+    println(io,"  APS         : range ϵ [$(minimum(d.APS)) - $(maximum(d.APS))]")
 
     return nothing
 end

--- a/src/LaMEM_ModelGeneration/Model.jl
+++ b/src/LaMEM_ModelGeneration/Model.jl
@@ -290,7 +290,7 @@ function create_initialsetup(model::Model, cores::Int64=1, args::String=""; verb
 
     if model.ModelSetup.msetup=="files"
         # write marker files to disk before running LaMEM
-        Model3D = CartData(model.Grid.Grid, (Phases=model.Grid.Phases,Temp=model.Grid.Temp));
+        Model3D = CartData(model.Grid.Grid, (Phases=model.Grid.Phases,Temp=model.Grid.Temp,APS=model.Grid.APS));
 
         if cores>1
             PartFile = run_lamem_save_grid(model.Output.param_file_name, cores)

--- a/src/LaMEM_ModelGeneration/Model.jl
+++ b/src/LaMEM_ModelGeneration/Model.jl
@@ -158,7 +158,7 @@ function write_LaMEM_inputFile(d::Model, fname::String="input.dat"; dir=pwd())
 
     if d.Output.write_VTK_setup
         # If we want to write an input file 
-        write_paraview(CartData(d.Grid.Grid, (Phases=d.Grid.Phases,Temp=d.Grid.Temp)),"Model3D")
+        write_paraview(CartData(d.Grid.Grid, (Phases=d.Grid.Phases,Temp=d.Grid.Temp,APS=d.Grid.APS)),"Model3D")
     end
     
     if any(hasplasticity.(d.Materials.Phases))

--- a/src/LaMEM_ModelGeneration/Output.jl
+++ b/src/LaMEM_ModelGeneration/Output.jl
@@ -168,6 +168,9 @@ Base.@kwdef mutable struct Output
     "temperature"
     out_ptr_Temperature  = 0    
 
+    "accumulated plastic strain"
+    out_ptr_APS  = 0    
+
     "melt fraction computed using P-T of the marker"
     out_ptr_MeltFraction = 0    
 

--- a/src/LaMEM_ModelGeneration/Utils.jl
+++ b/src/LaMEM_ModelGeneration/Utils.jl
@@ -288,7 +288,7 @@ end
 This creates a cross-section through the initial model setup & returns a 2D array
 """
 function cross_section(model::Model, field::Symbol=:phase; x=nothing, y=nothing, z=nothing)
-    Model3D = CartData(model.Grid.Grid, (phase=model.Grid.Phases,temperature=model.Grid.Temp));
+    Model3D = CartData(model.Grid.Grid, (phase=model.Grid.Phases,temperature=model.Grid.Temp,plast_strain=model.Grid.APS));
     
     data_tuple, axes_str = cross_section(Model3D, field; x=x, y=y, z=z)
     


### PR DESCRIPTION
I want to add the ability to set the initial APS, similar to how we can set the initial temperature and phases on the domain. Although pretty simple, this feature involves coordinated PRs in LaMEM, LaMEM.jl and GeophysicalModelGenerator.jl (see below). The changes are meant to be fully backwards compatible. I am leaving this as a draft as I want to get some feedback on the approach.

For more details, see the PR in the LaMEM repo (https://github.com/UniMainzGeo/LaMEM/pull/41)

## Summary of changes

**LaMEM.jl (this PR)**
- adds APS as a property of Grid and passes it to CartData
- adds ability to plot `plast_strain` as a cross-section (name matches Paraview field)
- adds `out_ptr_APS` option to include APS on passive tracers (defaults to 0)

GeophysicalModelGenerator.jl (add link)
- writes APS from Grid as an additional property in the marker binary file (defaults to 0 if not given)
- increments the file header to enable backwards compatibility

LaMEM (https://github.com/UniMainzGeo/LaMEM/pull/41)
- sets initial APS, if present, from marker binary file
- interprets the file header (previously ignored) as a version number to maintain backwards compatibility
- outputs APS as a field on markers
- optionally outputs APS as a field on passive tracers (defaults to no APS output)
- confirmed all tests pass locally