### PR TITLE
Ensure eta_min and p_litho_plast (in SolutionParams) match LaMEM defaults

### DIFF
--- a/src/LaMEM_ModelGeneration/SolutionParams.jl
+++ b/src/LaMEM_ModelGeneration/SolutionParams.jl
@@ -59,7 +59,7 @@ Base.@kwdef mutable struct SolutionParams
     p_litho_visc::Int64    = 1              
     
     "use lithostatic pressure for plasticity"
-    p_litho_plast::Int64   = 1         
+    p_litho_plast::Int64   = 0         
 
     "limit pressure at first iteration for plasticity"      
     p_lim_plast::Int64     = 1              
@@ -71,7 +71,7 @@ Base.@kwdef mutable struct SolutionParams
     act_p_shift::Int64       = 1 
 
     "viscosity lower bound [Pas]"
-    eta_min::Float64         = 1e18        
+    eta_min::Float64         = 0.0        
     
     "viscosity upper limit [Pas]   "
     eta_max::Float64         = 1e25         


### PR DESCRIPTION
Fixes #93.
Set the default values for these parameters to zero to match LaMEM, where they are uninitialized by default.
A future PR to LaMEM should explicitly initialize them to zero.
