### PR TITLE
Update LaMEM.jl to 0.4.16 (allow LaMEM_jll 2.2.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LaMEM"
 uuid = "2e889f3d-35ce-4a77-8ea2-858aecb630f7"
 authors = ["Boris Kaus <kaus@uni-mainz.de>"]
-version = "0.4.15"
+version = "0.4.16"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -32,10 +32,10 @@ GeoParams = "0.4, 0.5, 0.6, 0.7, 0.8"
 GeophysicalModelGenerator = "0.7.20"
 Glob = "1"
 Interpolations = "0.10 - 0.16"
-LaMEM_jll = "2.2.0"
+LaMEM_jll = "2.2.0, 2.2.1"
 LightXML = "0.9"
 MPI = "0.20"
-MPICH_jll = "4.2 - 4.2.3"
+MPICH_jll = "4.2 - 5"
 MPIPreferences = "0.1"
 Plots = "1"
 ReadVTK = "0.1, 0.2"


### PR DESCRIPTION
## Summary

Bumps **LaMEM.jl 0.4.15 → 0.4.16** and allows the newly-registered **LaMEM_jll 2.2.1**.

This PR is intentionally scoped to the **version + compat bump only**. Wrapping the new 2.2.1
model-generator parameters (erosion model 3, topographic diffusion, 3D Bezier `path_dim`,
time-dependent net plate motion) is implemented and tested locally but **held for a follow-up PR**
until the macOS binary issue below is resolved.

### Changes (`Project.toml` only)

| field | from | to |
|---|---|---|
| `version` | `0.4.15` | `0.4.16` |
| `[compat] LaMEM_jll` | `"2.2.0"` | `"2.2.0, 2.2.1"` |
| `[compat] MPICH_jll` | `"4.2 - 4.2.3"` | `"4.2 - 5"` |

The `MPICH_jll` widening is **required**: LaMEM_jll 2.2.1 raised its MPI floor to
`MPICH_jll = "4.3.0 - 5"` (registry `Compat.toml`), which does not intersect the old `"4.2 - 4.2.3"`
cap — without it the resolver silently falls back to 2.2.0. Verified locally: the project now
resolves to `LaMEM_jll 2.2.1` + `MPICH_jll 5.0.1`.

## CI results

| platform | result |
|---|---|
| Ubuntu x64 (Julia 1.10 / 1.11 / 1 / lts) | ✅ pass |
| Windows x64 (Julia 1 / 1.11 / lts) | ✅ pass |
| **macOS aarch64 + intel (all Julia versions)** | ❌ **fail** |

## Diagnosis of the macOS failures (⚠️ likely an upstream binary regression)

The macOS failures are **not** caused by this bump's wrapper changes. Two existing tests error:
`test/runLaMEM.jl:4` and `test/read_timestep.jl:5`. The failing operation is:

```julia
run_lamem(FallingBlock_DirectSolver.dat, 2, "-nstep_max 5")   # 2-core (parallel) MUMPS direct solve
```

which crashes inside PETSc/MUMPS:

```
Solver package : mumps
[0]PETSC ERROR: Caught signal number 11 SEGV: Segmentation Violation
Abort(59) on node 0 ... application called MPI_Abort(MPI_COMM_WORLD, 59)
```

Local diagnosis on macOS (x86_64) isolates it to the **binary**, not the wrapper:

- **Only parallel MUMPS** crashes — the single-core MUMPS solves in the same testset pass
  (`run LaMEM` = 3 pass / 1 error).
- **Not the MPI version** — reproduced with both `MPICH_jll 5.0.1` and `MPICH_jll 4.3.2`, so
  narrowing the MPICH compat does not help.
- **Regression vs 2.2.0** — on the same machine, pinning `LaMEM_jll = 2.2.0` + `MPICH_jll 4.2.3`
  and running the identical 2-core MUMPS solve **works**. Switching only to `LaMEM_jll 2.2.1`
  (PETSc 3.22.1) reproduces the SEGV.
- Linux x64 and Windows are unaffected.

⇒ This points to **LaMEM_jll 2.2.1 / PETSc_jll 3.22.1 (MUMPS) on macOS** as the source — i.e. an
upstream binary regression introduced between 2.2.0 (PETSc 3.22.0) and 2.2.1 (PETSc 3.22.1).
It is not fixable in LaMEM.jl wrapper code.

### Minimal local reproduction
```julia
import Pkg; Pkg.activate(temp=true)
Pkg.add(name="LaMEM_jll", version=v"2.2.1")   # vs 2.2.0 → works
using LaMEM
pf = joinpath(pkgdir(LaMEM),"test","input_files/FallingBlock_DirectSolver.dat")
run_lamem(pf, 2, "-nstep_max 5")              # 2-core MUMPS → SEGV on macOS
```

## Asking for guidance
Happy to follow up however you prefer:
- merge this bump now (macOS parallel-MUMPS direct solve becomes a known-broken path until the
  binary is fixed), and/or
- guard the macOS 2-core MUMPS test (`Sys.isapple()` / `@test_broken`) referencing an upstream
  issue, and/or
- hold until LaMEM_jll / PETSc_jll is rebuilt for macOS.

The 2.2.1 feature-wrapping follow-up is ready and will be opened once this lands.
